### PR TITLE
Amazon 商品情報チェッカーの処理から amazonads テーブル関係を廃止

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ w0s.jp サーバーで稼働しているシェルスクリプト
 | 名称 | 機能名 | 使用データベース | 概要 |
 |-|-|-|-|
 | [テスト](node/src/component/Test.ts) | Test | ― | 動作確認用。環境整備する際は、まずはこれが動くことを目指す。 |
-| [Amazon 商品情報チェッカー](node/src/component/AmazonAds.ts) | AmazonAds | blog, amazonads | Amazon 商品情報を PA-API を使用して取得し、 DB に格納済みのデータを照合して更新する。 |
+| [Amazon 商品情報チェッカー](node/src/component/AmazonAds.ts) | AmazonAds | blog | Amazon 商品情報を PA-API を使用して取得し、 DB に格納済みのデータを照合して更新する。 |
 | [ウェブ巡回（新着）](node/src/component/CrawlerNews.ts) | CrawlerNews | crawler | ウェブページを巡回し（HTML ページのみ）、新着情報の差分を調べて通知する。 |
 | [ウェブ巡回（リソース）](node/src/component/CrawlerResource.ts) | CrawlerResource | crawler | ウェブページを巡回し（HTML リソースに限らない）、レスポンスボディの差分を調べて通知する。 |
 | [JR 空席確認](node/src/component/JrCyberStation.ts) | JrCyberStation | ― | JR CYBER STATION で空席があれば通知する |

--- a/configure/schema/amazon-ads.json
+++ b/configure/schema/amazon-ads.json
@@ -3,40 +3,13 @@
 	"$id": "https://schema.w0s.jp/amazon-ads.json",
 	"type": "object",
 	"title": "Amazon 商品情報チェッカー",
-	"required": ["title", "ads_put", "blog_select_limit", "paapi"],
+	"required": ["title", "blog_select_limit", "paapi"],
 	"properties": {
 		"title": {
 			"type": "string",
 			"title": "コンポーネントタイトル",
 			"description": "自然言語による、人間が見て分かりやすい名前を設定する。通知メールの件名などで使用される。",
 			"examples": ["Amazon 商品情報チェッカー"]
-		},
-		"ads_put": {
-			"type": "object",
-			"title": "JSON ファイル生成",
-			"required": ["url_base", "auth"],
-			"properties": {
-				"url_base": {
-					"type": "string",
-					"title": "JSON ファイルを生成する URL"
-				},
-				"auth": {
-					"type": "object",
-					"title": "認証情報",
-					"required": ["username", "password"],
-					"properties": {
-						"username": {
-							"type": "string",
-							"title": "ユーザー名"
-						},
-						"password": {
-							"type": "string",
-							"title": "パスワード"
-						}
-					},
-					"additionalProperties": false
-				}
-			}
 		},
 		"blog_select_limit": {
 			"type": "integer",

--- a/node/src/component/AmazonAds.ts
+++ b/node/src/component/AmazonAds.ts
@@ -1,6 +1,5 @@
 // @ts-expect-error: ts(7016)
 import amazonPaapi from 'amazon-paapi';
-import { Buffer } from 'buffer';
 import { GetItemsResponse, Item } from 'paapi5-typescript-sdk';
 import AmazonAdsDao from '../dao/AmazonAdsDao.js';
 import Component from '../Component.js';
@@ -30,15 +29,11 @@ export default class AmazonAds extends Component implements ComponentInterface {
 		if (this.configCommon.sqlite.db.blog === undefined) {
 			throw new Error('共通設定ファイルに blog テーブルのパスが指定されていない。');
 		}
-		if (this.configCommon.sqlite.db.amazon_ads === undefined) {
-			throw new Error('共通設定ファイルに amazonads テーブルのパスが指定されていない。');
-		}
 
 		const dao = new AmazonAdsDao(this.configCommon);
 
 		/* 処理対象の ASIN を取得する */
-		const [targetAsinsBlog, targetAsinsAmazonAds] = await Promise.all([dao.getAsinsBlog(this.#config.blog_select_limit), dao.getAsinsAmazonAds()]);
-		const targetAsins = [...new Set(targetAsinsBlog.concat(targetAsinsAmazonAds))]; // マージした上で重複した値を削除する
+		const targetAsins = await dao.getAsinsBlog(this.#config.blog_select_limit);
 		this.logger.debug('処理対象の ASIN', targetAsins);
 
 		const targetAsinsChunk: string[][] = new Array(Math.ceil(targetAsins.length / this.#config.paapi.getitems_itemids_chunk)).fill([]).map((_, index) => {
@@ -48,7 +43,6 @@ export default class AmazonAds extends Component implements ComponentInterface {
 
 		/* PA-API を使用してデータを取得する */
 		const diffsBlog: Map<string, Diff>[] = [];
-		const diffsAmazonAds: Map<string, Diff>[] = [];
 
 		await Promise.all(
 			targetAsinsChunk.map(async (asins, index) => {
@@ -88,11 +82,8 @@ export default class AmazonAds extends Component implements ComponentInterface {
 					this.logger.debug(item);
 
 					const asin = item.ASIN;
-					if (targetAsinsBlog.includes(asin)) {
+					if (targetAsins.includes(asin)) {
 						diffsBlog.push(await this.#blog(dao, item, asin));
-					}
-					if (targetAsinsAmazonAds.includes(asin)) {
-						diffsAmazonAds.push(await this.#amazonAds(dao, item, asin));
 					}
 				}
 			})
@@ -102,12 +93,6 @@ export default class AmazonAds extends Component implements ComponentInterface {
 		if (diffsBlog.some((diff) => diff.size >= 1)) {
 			/* DB の更新日時を更新 */
 			await dao.updateBlogModified();
-		}
-
-		this.logger.debug(diffsAmazonAds);
-		if (diffsAmazonAds.some((diff) => diff.size >= 1)) {
-			/* Web ページで使用する JSON ファイルを出力 */
-			await this.#createJson();
 		}
 	}
 
@@ -195,108 +180,5 @@ export default class AmazonAds extends Component implements ComponentInterface {
 		});
 
 		return diff;
-	}
-
-	/**
-	 * amazonads テーブルの処理
-	 *
-	 * @param {AmazonAdsDao} dao - dao クラス
-	 * @param {Item} item - Item クラス
-	 * @param {string} asin - ASIN
-	 *
-	 * @returns {Map<string, Diff>} API から取得した値と DB に格納済みの値の差分情報
-	 */
-	async #amazonAds(dao: AmazonAdsDao, item: Item, asin: string): Promise<Map<string, Diff>> {
-		const apiDpUrl = item.DetailPageURL; // 詳細ページURL
-		const apiTitle = item.ItemInfo?.Title?.DisplayValue ?? null; // 製品タイトル
-		if (apiTitle === null) {
-			// TODO: API 的には null の可能性があるが、 DB のカラムは NOT NULL なための暫定処理
-			throw new Error(`PA-API に商品タイトルが登録されていない: ${asin}`);
-		}
-		const apiBinding = item.ItemInfo?.Classifications?.Binding.DisplayValue ?? null; // 製品カテゴリ
-		const apiPublicationDateStr = item.ItemInfo?.ContentInfo?.PublicationDate?.DisplayValue ?? null; // 製品公開日
-		let apiPublicationDate: Date | null = null;
-		if (apiPublicationDateStr !== null) {
-			try {
-				apiPublicationDate = PaapiUtil.date(apiPublicationDateStr);
-			} catch (e) {
-				this.logger.error(e);
-			}
-		}
-		const apiImage = item.Images?.Primary?.Large;
-		const apiImageUrl = apiImage?.URL ?? null; // 画像URL
-		const apiImageWidth = apiImage?.Width !== undefined ? Number(apiImage?.Width) : null; // 画像幅
-		const apiImageHeight = apiImage?.Height !== undefined ? Number(apiImage?.Height) : null; // 画像高さ
-
-		this.logger.debug(`amazonads データベースの d_dp テーブルから ASIN: ${asin} の検索処理を開始`);
-
-		const db = await dao.selectAmazonAds(asin);
-
-		const diff = new Map<string, Diff>(); // API から取得した値と DB に格納済みの値を比較し、その差分情報を格納する
-		if (apiDpUrl !== db.dp_url) {
-			diff.set('detailPageURL', { db: db.dp_url, api: apiDpUrl });
-		}
-		if (apiTitle !== db.title) {
-			diff.set('title', { db: db.title, api: String(apiTitle) });
-		}
-		if (apiBinding !== db.binding) {
-			diff.set('binding', { db: String(db.binding), api: String(apiBinding) });
-		}
-		if (apiPublicationDate?.getTime() !== db.publication_date?.getTime()) {
-			diff.set('publicationDate', { db: String(db.publication_date), api: String(apiPublicationDate) });
-		}
-		if (apiImageUrl !== db.image_url) {
-			diff.set('imageUrl', { db: String(db.image_url), api: String(apiImageUrl) });
-
-			if (db.image_url === null) {
-				/* 今回の巡回で画像が追加された場合 */
-				this.notice.push(`画像アップ: 「${apiTitle}」 ${apiDpUrl}`);
-			} else {
-				this.notice.push(`画像更新: 「${apiTitle}」 ${apiDpUrl}`);
-			}
-		}
-
-		if (diff.size === 0) {
-			this.logger.debug(`${asin} の情報に変更がないので DB の更新処理は行わない`);
-			return diff;
-		}
-
-		/* 更新処理を行う */
-		this.logger.info(`${asin} の情報が更新`, diff);
-
-		await dao.updateAmazonAds({
-			asin: asin,
-			dp_url: apiDpUrl,
-			title: apiTitle,
-			binding: apiBinding,
-			publication_date: apiPublicationDate,
-			image_url: apiImageUrl,
-			image_width: apiImageWidth,
-			image_height: apiImageHeight,
-		});
-
-		return diff;
-	}
-
-	/**
-	 * Web ページで使用する JSON ファイルを出力
-	 */
-	async #createJson(): Promise<void> {
-		const endPoint = this.#config.ads_put.url_base;
-		this.logger.info('Fetch', endPoint);
-
-		try {
-			const response = await fetch(endPoint, {
-				method: 'post',
-				headers: {
-					Authorization: `Basic ${Buffer.from(`${this.#config.ads_put.auth.username}:${this.#config.ads_put.auth.password}`).toString('base64')}`,
-				},
-			});
-			if (!response.ok) {
-				this.logger.error('Fetch error', endPoint);
-			}
-		} catch (e) {
-			this.logger.error(e);
-		}
 	}
 }


### PR DESCRIPTION
以下の対応に関連して、amazonads テーブルはもう使用しないのでチェック対象から外す。

- SaekiTominaga/w0s.jp/pull/310
- SaekiTominaga/blog.w0s.jp/pull/280