### PR TITLE
「ウェブ巡回（リソース）」の差分比較をコンテンツの長さ→ハッシュ値に変更

### DIFF
--- a/node/@types/db.d.ts
+++ b/node/@types/db.d.ts
@@ -26,7 +26,7 @@ declare namespace CrawlerDb {
 		priority: number;
 		browser: boolean;
 		selector: string | null;
-		content_length: number;
+		content_hash: string;
 		modified_at: Date | null;
 		error: number;
 	}

--- a/node/@types/db.d.ts
+++ b/node/@types/db.d.ts
@@ -22,7 +22,7 @@ declare namespace CrawlerDb {
 	export interface Resource {
 		url: string;
 		title: string;
-		class: number;
+		category: number;
 		priority: number;
 		browser: boolean;
 		selector: string | null;

--- a/node/@types/db.d.ts
+++ b/node/@types/db.d.ts
@@ -27,7 +27,6 @@ declare namespace CrawlerDb {
 		browser: boolean;
 		selector: string | null;
 		content_hash: string;
-		modified_at: Date | null;
 		error: number;
 	}
 }

--- a/node/src/dao/CrawlerResourceDao.ts
+++ b/node/src/dao/CrawlerResourceDao.ts
@@ -60,7 +60,7 @@ export default class CrawlerResourceDao {
 				priority,
 				browser,
 				selector,
-				content_length,
+				content_hash,
 				last_modified AS modified_at,
 				error
 			FROM
@@ -83,7 +83,7 @@ export default class CrawlerResourceDao {
 				priority: row.priority,
 				browser: Boolean(row.browser),
 				selector: row.selector,
-				content_length: row.content_length,
+				content_hash: row.content_hash,
 				modified_at: DbUtil.unixToDate(row.modified_at),
 				error: row.error,
 			});
@@ -96,10 +96,10 @@ export default class CrawlerResourceDao {
 	 * 登録データを更新する
 	 *
 	 * @param data - 登録データ
-	 * @param contentLength - サイズ
+	 * @param contetnHash - コンテンツのハッシュ値
 	 * @param lastModified - 更新日時
 	 */
-	async update(data: CrawlerDb.Resource, contentLength: number, lastModified: Date | null): Promise<void> {
+	async update(data: CrawlerDb.Resource, contetnHash: string, lastModified: Date | null): Promise<void> {
 		const dbh = await this.getDbh();
 
 		await dbh.exec('BEGIN');
@@ -108,14 +108,14 @@ export default class CrawlerResourceDao {
 				UPDATE
 					d_resource
 				SET
-					last_modified = :last_modified,
-					content_length = :content_length
+					content_hash = :content_hash,
+					last_modified = :last_modified
 				WHERE
 					url = :url
 			`);
 			await sth.run({
+				':content_hash': contetnHash,
 				':last_modified': DbUtil.dateToUnix(lastModified),
-				':content_length': contentLength,
 				':url': data.url,
 			});
 			await sth.finalize();

--- a/node/src/dao/CrawlerResourceDao.ts
+++ b/node/src/dao/CrawlerResourceDao.ts
@@ -55,7 +55,7 @@ export default class CrawlerResourceDao {
 			SELECT
 				url,
 				title,
-				class,
+				category,
 				priority,
 				browser,
 				selector,
@@ -77,7 +77,7 @@ export default class CrawlerResourceDao {
 			datas.push({
 				url: row.url,
 				title: row.title,
-				class: row.class,
+				category: row.category,
 				priority: row.priority,
 				browser: Boolean(row.browser),
 				selector: row.selector,

--- a/node/src/dao/CrawlerResourceDao.ts
+++ b/node/src/dao/CrawlerResourceDao.ts
@@ -1,6 +1,5 @@
 import * as sqlite from 'sqlite';
 import sqlite3 from 'sqlite3';
-import DbUtil from '../util/DbUtil.js';
 
 /**
  * ウェブ巡回（リソース）
@@ -61,7 +60,6 @@ export default class CrawlerResourceDao {
 				browser,
 				selector,
 				content_hash,
-				last_modified AS modified_at,
 				error
 			FROM
 				d_resource
@@ -84,7 +82,6 @@ export default class CrawlerResourceDao {
 				browser: Boolean(row.browser),
 				selector: row.selector,
 				content_hash: row.content_hash,
-				modified_at: DbUtil.unixToDate(row.modified_at),
 				error: row.error,
 			});
 		}
@@ -97,9 +94,8 @@ export default class CrawlerResourceDao {
 	 *
 	 * @param data - 登録データ
 	 * @param contetnHash - コンテンツのハッシュ値
-	 * @param lastModified - 更新日時
 	 */
-	async update(data: CrawlerDb.Resource, contetnHash: string, lastModified: Date | null): Promise<void> {
+	async update(data: CrawlerDb.Resource, contetnHash: string): Promise<void> {
 		const dbh = await this.getDbh();
 
 		await dbh.exec('BEGIN');
@@ -108,14 +104,12 @@ export default class CrawlerResourceDao {
 				UPDATE
 					d_resource
 				SET
-					content_hash = :content_hash,
-					last_modified = :last_modified
+					content_hash = :content_hash
 				WHERE
 					url = :url
 			`);
 			await sth.run({
 				':content_hash': contetnHash,
-				':last_modified': DbUtil.dateToUnix(lastModified),
 				':url': data.url,
 			});
 			await sth.finalize();


### PR DESCRIPTION
- コンテンツの長さによる比較を止めてハッシュ値による比較へ変更
- `Last-Modified` ヘッダによる比較を廃止（HEAD アクセスしているわけでもなく、処理的な効率化に寄与しないため）
- テーブルのカラム名変更（`class` → `category`）