### PR TITLE
「fetch failed」のエラー発生時に対象 URL が判別できるようにする

### DIFF
--- a/node/src/component/CrawlerNews.ts
+++ b/node/src/component/CrawlerNews.ts
@@ -347,11 +347,6 @@ export default class CrawlerNews extends Component implements ComponentInterface
 			};
 		} catch (e) {
 			if (e instanceof Error) {
-				if (e.message.startsWith('net::ERR_TOO_MANY_REDIRECTS at https://www.threads.net')) {
-					this.logger.warn(e.message);
-					return null;
-				}
-
 				this.logger.error(e.message, targetData.url);
 			} else {
 				this.logger.error(e, targetData.url);

--- a/node/src/component/CrawlerNews.ts
+++ b/node/src/component/CrawlerNews.ts
@@ -279,9 +279,9 @@ export default class CrawlerNews extends Component implements ComponentInterface
 					default:
 				}
 
-				this.logger.error(e.message);
+				this.logger.error(e.message, targetData.url);
 			} else {
-				this.logger.error(e);
+				this.logger.error(e, targetData.url);
 			}
 
 			return null;
@@ -352,9 +352,9 @@ export default class CrawlerNews extends Component implements ComponentInterface
 					return null;
 				}
 
-				this.logger.error(e.message);
+				this.logger.error(e.message, targetData.url);
 			} else {
-				this.logger.error(e);
+				this.logger.error(e, targetData.url);
 			}
 
 			return null;

--- a/node/src/component/CrawlerResource.ts
+++ b/node/src/component/CrawlerResource.ts
@@ -239,11 +239,6 @@ export default class CrawlerResource extends Component implements ComponentInter
 			};
 		} catch (e) {
 			if (e instanceof Error) {
-				if (e.message.startsWith('net::ERR_TOO_MANY_REDIRECTS at https://www.threads.net')) {
-					this.logger.warn(e.message);
-					return null;
-				}
-
 				this.logger.error(e.message, targetData.url);
 			} else {
 				this.logger.error(e, targetData.url);

--- a/node/src/component/CrawlerResource.ts
+++ b/node/src/component/CrawlerResource.ts
@@ -171,9 +171,9 @@ export default class CrawlerResource extends Component implements ComponentInter
 					default:
 				}
 
-				this.logger.error(e.message);
+				this.logger.error(e.message, targetData.url);
 			} else {
-				this.logger.error(e);
+				this.logger.error(e, targetData.url);
 			}
 
 			return null;
@@ -244,9 +244,9 @@ export default class CrawlerResource extends Component implements ComponentInter
 					return null;
 				}
 
-				this.logger.error(e.message);
+				this.logger.error(e.message, targetData.url);
 			} else {
-				this.logger.error(e);
+				this.logger.error(e, targetData.url);
 			}
 
 			return null;


### PR DESCRIPTION
従来、fetch failed のエラーが発生した場合は具体的にどの URL が分からなかったので、エラーメッセージに URL を追加する