### PR TITLE
横浜市立図書館蔵書検索のリニューアルに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # w0s.jp-shell
 
-w0s.jp サーバーで稼働しているシェルスクリプト
+`w0s.jp` サーバーで稼働しているシェルスクリプト
 
 ## おことわり
 
@@ -10,11 +10,11 @@ w0s.jp サーバーで稼働しているシェルスクリプト
 
 | 名称 | 機能名 | 使用データベース | 概要 |
 |-|-|-|-|
-| [テスト](node/src/component/Test.ts) | Test | ― | 動作確認用。環境整備する際は、まずはこれが動くことを目指す。 |
-| [ウェブ巡回（新着）](node/src/component/CrawlerNews.ts) | CrawlerNews | crawler | ウェブページを巡回し（HTML ページのみ）、新着情報の差分を調べて通知する。 |
-| [ウェブ巡回（リソース）](node/src/component/CrawlerResource.ts) | CrawlerResource | crawler | ウェブページを巡回し（HTML リソースに限らない）、レスポンスボディの差分を調べて通知する。 |
+| [テスト](node/src/component/Test.ts) | Test | ― | 動作確認用。環境整備の際はまずはこれが動くことを目指す |
+| [ウェブ巡回（新着）](node/src/component/CrawlerNews.ts) | CrawlerNews | crawler | ウェブページを巡回し（HTML ページのみ）、新着情報の差分を調べて通知する |
+| [ウェブ巡回（リソース）](node/src/component/CrawlerResource.ts) | CrawlerResource | crawler | ウェブページを巡回し（HTML リソースに限らない）、レスポンスボディの差分を調べて通知する |
 | [JR 空席確認](node/src/component/JrCyberStation.ts) | JrCyberStation | ― | JR CYBER STATION で空席があれば通知する |
-| [横浜市立図書館　予約連絡](node/src/component/YokohamaLibraryHoldNotice.ts) | YokohamaLibraryHoldNotice | ― | [横浜市立図書館蔵書検索](https://opac.lib.city.yokohama.lg.jp/opac/)で予約した本は受取可能になっても予約連絡メールが送信されるのは翌朝なので、到着日に受け取れるようログインページをスクレイピングして独自に通知メールを送る。（受け取り可能になる時間帯は各館によって概ね決まっているため、その時間帯に実行すれば良い） |
+| [横浜市立図書館　予約連絡](node/src/component/YokohamaLibraryHoldNotice.ts) | YokohamaLibraryHoldNotice | ― | [横浜市立図書館蔵書検索](https://opac.lib.city.yokohama.lg.jp/winj/opac/top.do?lang=ja)で予約した本は受取可能になっても連絡メールは翌朝配信なため、到着日に受け取れるようログインページをスクレイピングして独自に通知メールを送る（受取可能になる時間帯は各館によって概ね決まっているため、その時間帯に実行する） |
 
 ## 動作手順
 

--- a/configure/schema/yokohama-library-hold-notice.json
+++ b/configure/schema/yokohama-library-hold-notice.json
@@ -3,16 +3,16 @@
 	"$id": "https://schema.w0s.jp/yokohama-library-hold-notice.json",
 	"type": "object",
 	"title": "横浜市立図書館　予約連絡",
-	"required": ["title", "id", "password", "url", "login", "ready", "notice"],
+	"required": ["title", "card", "password", "url", "login", "ready", "notice"],
 	"properties": {
 		"title": {
 			"type": "string",
 			"title": "コンポーネントタイトル",
 			"description": "自然言語による、人間が見て分かりやすい名前を設定する。通知メールの件名などで使用される。"
 		},
-		"id": {
+		"card": {
 			"type": "string",
-			"title": "ユーザー ID（図書館カード番号）"
+			"title": "図書館カード番号"
 		},
 		"password": {
 			"type": "string",
@@ -25,9 +25,13 @@
 		"login": {
 			"type": "object",
 			"title": "ログインフォーム",
-			"required": ["idSelector", "passwordSelector", "submitSelector", "errorSelector"],
+			"required": ["url", "cardSelector", "passwordSelector", "submitSelector", "errorSelector"],
 			"properties": {
-				"idSelector": {
+				"url": {
+					"type": "string",
+					"title": "ログイン URL"
+				},
+				"cardSelector": {
 					"type": "string",
 					"title": "ユーザー ID 入力欄のセレクター"
 				},
@@ -38,10 +42,6 @@
 				"submitSelector": {
 					"type": "string",
 					"title": "送信ボタンのセレクター"
-				},
-				"errorSelector": {
-					"type": "string",
-					"title": "エラーメッセージのセレクター"
 				}
 			},
 			"additionalProperties": false
@@ -49,7 +49,7 @@
 		"ready": {
 			"type": "object",
 			"title": "新着予約があった場合にのみ表示される通知ページの情報",
-			"required": ["wrapSelector", "titleSelector", "confirmButtonSelector"],
+			"required": ["wrapSelector", "titleSelector", "availableSelector"],
 			"properties": {
 				"wrapSelector": {
 					"type": "string",
@@ -59,9 +59,9 @@
 					"type": "string",
 					"title": "資料名のセレクター"
 				},
-				"confirmButtonSelector": {
+				"availableSelector": {
 					"type": "string",
-					"title": "確認ボタンのセレクター"
+					"title": "「受取可」アイコンのセレクター"
 				}
 			},
 			"additionalProperties": false


### PR DESCRIPTION
2024年1月15日にシステムリニューアルされた。👉[令和6年1月に図書館情報システムが新しくなりました　横浜市](https://www.city.yokohama.lg.jp/kurashi/kyodo-manabi/library/oshirase/2024opacrenewal.html)