### PR TITLE
横浜市立図書館蔵書検索の受け取り可能データを DB に状態保存するようにした

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,12 @@
 				"no-await-in-loop": "off",
 				"no-loop-func": "off"
 			}
+		},
+		{
+			"files": ["node/src/component/YokohamaLibraryHoldNotice.ts"],
+			"rules": {
+				"no-await-in-loop": "off"
+			}
 		}
 	]
 }

--- a/configure/schema/yokohama-library-hold-notice.json
+++ b/configure/schema/yokohama-library-hold-notice.json
@@ -25,7 +25,7 @@
 		"login": {
 			"type": "object",
 			"title": "ログインフォーム",
-			"required": ["url", "cardSelector", "passwordSelector", "submitSelector", "errorSelector"],
+			"required": ["url", "cardSelector", "passwordSelector", "submitSelector"],
 			"properties": {
 				"url": {
 					"type": "string",
@@ -49,11 +49,15 @@
 		"reserve": {
 			"type": "object",
 			"title": "予約中ページの情報",
-			"required": ["wrapSelector", "titleSelector", "availableSelector"],
+			"required": ["wrapSelector", "typeSelector", "titleSelector", "availableSelector"],
 			"properties": {
 				"wrapSelector": {
 					"type": "string",
 					"title": "包括要素のセレクター"
+				},
+				"typeSelector": {
+					"type": "string",
+					"title": "資料区分のセレクター"
 				},
 				"titleSelector": {
 					"type": "string",

--- a/node/@types/db.d.ts
+++ b/node/@types/db.d.ts
@@ -31,35 +31,6 @@ declare namespace CrawlerDb {
 	}
 }
 
-declare namespace KumetaTwitterDb {
-	export interface User {
-		id: string;
-		username: string;
-		name: string;
-		location: string | null;
-		description: string | null;
-		url: string | null;
-		followers: number | null;
-		following: number | null;
-		created_at: Date | null;
-	}
-
-	export interface ProfileImage {
-		id: string;
-		url: string | null;
-		url_api: string | null;
-		file_name: string | null;
-		registed_at: Date;
-	}
-
-	export interface Banner {
-		id: string;
-		url: string | null;
-		file_name: string | null;
-		registed_at: Date;
-	}
-}
-
 declare namespace ThumbImageDb {
 	export interface Queue {
 		file_path: string;
@@ -68,5 +39,12 @@ declare namespace ThumbImageDb {
 		height: number;
 		quality: number | null;
 		registered_at: Date;
+	}
+}
+
+declare namespace YokohamaLibraryDb {
+	export interface Available {
+		type: string;
+		title: string;
 	}
 }

--- a/node/src/component/YokohamaLibraryHoldNotice.ts
+++ b/node/src/component/YokohamaLibraryHoldNotice.ts
@@ -2,6 +2,7 @@ import puppeteer from 'puppeteer-core';
 import { JSDOM } from 'jsdom';
 import Component from '../Component.js';
 import type ComponentInterface from '../ComponentInterface.js';
+import YokohamaLibraryDao from '../dao/YokohamaLibraryDao.js';
 import type { NoName as ConfigureYokohamaLibraryHoldNotice } from '../../../configure/type/yokohama-library-hold-notice.js';
 
 /**
@@ -10,14 +11,24 @@ import type { NoName as ConfigureYokohamaLibraryHoldNotice } from '../../../conf
 export default class YokohamaLibraryHoldNotice extends Component implements ComponentInterface {
 	readonly #config: ConfigureYokohamaLibraryHoldNotice;
 
+	readonly #dao: YokohamaLibraryDao;
+
 	constructor() {
 		super();
 
 		this.#config = this.readConfig() as ConfigureYokohamaLibraryHoldNotice;
 		this.title = this.#config.title;
+
+		const dbFilePath = this.configCommon.sqlite.db['yokohama_lib'];
+		if (dbFilePath === undefined) {
+			throw new Error('共通設定ファイルに yokohamalib テーブルのパスが指定されていない。');
+		}
+		this.#dao = new YokohamaLibraryDao(dbFilePath);
 	}
 
 	async execute(): Promise<void> {
+		const availableBooks: { type: string; title: string }[] = [];
+
 		/* ブラウザで対象ページにアクセス */
 		const browser = await puppeteer.launch({ executablePath: this.configCommon.browser.path });
 		try {
@@ -43,30 +54,61 @@ export default class YokohamaLibraryHoldNotice extends Component implements Comp
 			/* DOM 化 */
 			const { document } = new JSDOM(response).window;
 
-			const availableBooksTitle: string[] = [];
-
 			document.querySelectorAll<HTMLElement>(this.#config.reserve.wrapSelector).forEach((bookElement): void => {
 				if (bookElement.querySelector(this.#config.reserve.availableSelector) === null) {
 					/* 準備中、回送中の本は除外 */
 					return;
 				}
 
-				const bookTitle = bookElement.querySelector(this.#config.reserve.titleSelector)?.textContent;
-				if (bookTitle === null || bookTitle === undefined) {
-					throw new Error(`書名の HTML 要素（${this.#config.reserve.titleSelector}）が存在しない`);
+				const type = bookElement.querySelector(this.#config.reserve.titleSelector)?.textContent;
+				if (type === null || type === undefined) {
+					throw new Error(`資料区分の HTML 要素（${this.#config.reserve.titleSelector}）が存在しない`);
 				}
 
-				availableBooksTitle.push(bookTitle.trim().replaceAll('\n', ' '));
-			});
+				const title = bookElement.querySelector(this.#config.reserve.titleSelector)?.textContent;
+				if (title === null || title === undefined) {
+					throw new Error(`資料名の HTML 要素（${this.#config.reserve.titleSelector}）が存在しない`);
+				}
 
-			if (availableBooksTitle.length === 0) {
-				this.logger.info('新着予約なし');
-			} else {
-				this.notice.push(`${this.#config.notice.messagePrefix}${availableBooksTitle.join('\n')}\n\n${this.#config.url}${this.#config.notice.messageSuffix}`);
-			}
+				availableBooks.push({
+					type: type,
+					title: title.trim().replaceAll('\n', ' '),
+				});
+			});
 		} finally {
 			this.logger.debug('browser.close()');
 			await browser.close();
+		}
+
+		this.logger.info(`受取可能資料 ${availableBooks.length} 件`);
+
+		/* DB に登録済みで Web ページに未記載のデータを削除 */
+		for (const registedBook of await this.#dao.selectAvailables()) {
+			if (!availableBooks.some((availableBook) => availableBook.type === registedBook.type && availableBook.title === registedBook.title)) {
+				this.logger.debug('データ削除', registedBook);
+				await this.#dao.deleteAvailable(registedBook.type, registedBook.title);
+			}
+		}
+
+		/* Web ページに記載されていて DB に未登録のデータを削除 */
+		const noticeBooks: { type: string; title: string }[] = [];
+
+		for (const availableBook of availableBooks) {
+			const registedBook = await this.#dao.selectAvailable(availableBook.type, availableBook.title);
+			if (registedBook === null) {
+				this.logger.debug('データ追加', availableBook);
+				await this.#dao.insertAvailable(availableBook.type, availableBook.title);
+
+				noticeBooks.push(availableBook);
+			}
+		}
+
+		if (noticeBooks.length >= 1) {
+			this.notice.push(
+				`${this.#config.notice.messagePrefix}${noticeBooks.map((book) => `${book.type}${book.title}`).join('\n')}\n\n${this.#config.url}${
+					this.#config.notice.messageSuffix
+				}`,
+			);
 		}
 	}
 }

--- a/node/src/dao/YokohamaLibraryDao.ts
+++ b/node/src/dao/YokohamaLibraryDao.ts
@@ -1,0 +1,172 @@
+import * as sqlite from 'sqlite';
+import sqlite3 from 'sqlite3';
+
+/**
+ * 横浜市立図書館
+ */
+export default class YokohamaLibraryDao {
+	#dbh: sqlite.Database | null = null;
+
+	readonly #filepath: string;
+
+	/**
+	 * @param filepath - DB ファイルパス
+	 * @param dbh - DB 接続情報
+	 */
+	constructor(filepath: string, dbh?: sqlite.Database) {
+		this.#filepath = filepath;
+
+		if (dbh !== undefined) {
+			this.#dbh = dbh;
+		}
+	}
+
+	/**
+	 * DB 接続情報を取得する
+	 *
+	 * @returns DB 接続情報
+	 */
+	async getDbh(): Promise<sqlite.Database> {
+		if (this.#dbh !== null) {
+			return this.#dbh;
+		}
+
+		const dbh = await sqlite.open({
+			filename: this.#filepath,
+			driver: sqlite3.Database,
+		});
+
+		this.#dbh = dbh;
+
+		return dbh;
+	}
+
+	/**
+	 * 受取可データを取得する
+	 *
+	 * @param type - 資料区分
+	 * @param title - 資料名
+	 *
+	 * @returns 登録データ
+	 */
+	async selectAvailable(type: string, title: string): Promise<YokohamaLibraryDb.Available | null> {
+		const dbh = await this.getDbh();
+
+		const sth = await dbh.prepare(`
+			SELECT
+				type,
+				title
+			FROM
+				d_available
+			WHERE
+				type = :type AND
+				title = :title
+		`);
+		await sth.bind({
+			':type': type,
+			':title': title,
+		});
+		const row = await sth.get();
+		await sth.finalize();
+
+		if (row === undefined) {
+			return null;
+		}
+
+		return {
+			type: row.type,
+			title: row.title,
+		};
+	}
+
+	/**
+	 * 受取可データを全取得する
+	 *
+	 * @returns 登録データ
+	 */
+	async selectAvailables(): Promise<YokohamaLibraryDb.Available[]> {
+		const dbh = await this.getDbh();
+
+		const sth = await dbh.prepare(`
+			SELECT
+				type,
+				title
+			FROM
+				d_available
+		`);
+		const rows = await sth.all();
+		await sth.finalize();
+
+		const datas: YokohamaLibraryDb.Available[] = [];
+		for (const row of rows) {
+			datas.push({
+				type: row.type,
+				title: row.title,
+			});
+		}
+
+		return datas;
+	}
+
+	/**
+	 * 受取可データを登録する
+	 *
+	 * @param type - 資料区分
+	 * @param title - 資料名
+	 */
+	async insertAvailable(type: string, title: string): Promise<void> {
+		const dbh = await this.getDbh();
+
+		await dbh.exec('BEGIN');
+		try {
+			const sth = await dbh.prepare(`
+				INSERT INTO
+					d_available
+					(type, title)
+				VALUES
+					(:type, :title)
+			`);
+			await sth.run({
+				':type': type,
+				':title': title,
+			});
+			await sth.finalize();
+
+			await dbh.exec('COMMIT');
+		} catch (e) {
+			await dbh.exec('ROLLBACK');
+			throw e;
+		}
+	}
+
+	/**
+	 * 受取可データを削除する
+	 *
+	 * @param type - 資料区分
+	 * @param title - 資料名
+	 */
+	async deleteAvailable(type: string, title: string): Promise<void> {
+		const dbh = await this.getDbh();
+
+		await dbh.exec('BEGIN');
+		try {
+			const sth = await dbh.prepare(`
+				DELETE FROM
+					d_available
+				WHERE
+					type = :type AND
+					title = :title
+			`);
+			await sth.run({
+				':type': type,
+				':title': title,
+			});
+			await sth.finalize();
+
+			await dbh.exec('COMMIT');
+		} catch (e) {
+			await dbh.exec('ROLLBACK');
+			throw e;
+		}
+	}
+}


### PR DESCRIPTION
#58 でシステムリニューアルの対応を行ったが、これは暫定対応で、受け取り可能資料が1件以上ある場合プログラム実行ごとに毎回通知が来てしまうものであった。

そのため DB に現在状態を保存するようにし、通知はプログラム実行回数に関わらず1回のみ行われるようにした。