### PR TITLE
横浜市立図書館蔵書検索のログインページ表示エラー改善

### DIFF
--- a/node/src/component/YokohamaLibraryHoldNotice.ts
+++ b/node/src/component/YokohamaLibraryHoldNotice.ts
@@ -40,7 +40,7 @@ export default class YokohamaLibraryHoldNotice extends Component implements Comp
 			});
 
 			/* ログイン */
-			await page.goto(this.#config.url, { waitUntil: 'domcontentloaded' });
+			await page.goto(this.#config.url);
 			await page.goto(this.#config.login.url, { waitUntil: 'domcontentloaded' });
 			await page.type(this.#config.login.cardSelector, this.#config.card);
 			await page.type(this.#config.login.passwordSelector, this.#config.password);


### PR DESCRIPTION
ログインページが正常に表示されないことがあるため、トップページの読み込み完了検知を `domcontentloaded` から `load` に変更