### PR TITLE
[横浜市立図書館] ログイン後のリダイレクト先 URL のチェック処理を追加

### DIFF
--- a/node/src/config/yokohamaLibraryHoldNotice.ts
+++ b/node/src/config/yokohamaLibraryHoldNotice.ts
@@ -2,6 +2,7 @@ export default {
 	url: 'https://opac.lib.city.yokohama.lg.jp/winj/opac/top.do',
 	login: {
 		url: 'https://opac.lib.city.yokohama.lg.jp/winj/opac/login.do?dispatch=/opac/reserve-list.do',
+		postUrl: 'https://opac.lib.city.yokohama.lg.jp/winj/opac/reserve-list.do',
 		timeout: 45,
 		cardSelector: '#usercd',
 		passwordSelector: '#password',


### PR DESCRIPTION
ログイン後に再びログインページが開かれてしまう事象が多発しているため、URL のチェック処理を追加することで「受取可能資料が0件（到着本を受け取った扱い）となる」事態を避ける。
合わせて調査のためにログ書き出しを多めにしておく。