### PR TITLE
Github Action 上での JavaScript ファイルの test を削除

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -20,12 +20,3 @@ jobs:
           node-version: '22'
       - run: npm ci
       - run: npm run lint
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - run: npm ci
-      - run: npm test


### PR DESCRIPTION
#100 で追加したが、よく考えたら .env ファイルがないと動かないのでローカルでのみしか実施できない