### PR TITLE
ウェブ巡回（ニュース）で同じページに複数の同一内容が存在した場合に登録が行われないバグを修正

### DIFF
--- a/node/src/component/crawlerNews.ts
+++ b/node/src/component/crawlerNews.ts
@@ -210,11 +210,6 @@ const exec = async (notice: Notice): Promise<void> => {
 				continue;
 			}
 
-			if (await dao.existData(targetData.url, date, contentText)) {
-				logger.debug(`データ登録済み: ${contentText.substring(0, 30)}...`);
-				continue;
-			}
-
 			/* アンカーリンク抽出 */
 			let referUrl: string | undefined;
 			const newsAnchorElements = contentElement.querySelectorAll<HTMLAnchorElement>('a[href]');
@@ -222,6 +217,11 @@ const exec = async (notice: Notice): Promise<void> => {
 				/* メッセージ内にリンクが一つだけある場合のみ、その URL を対象ページとする */
 				referUrl = resolve(newsAnchorElements.item(0).href.trim(), targetData.url.toString());
 				logger.debug('URL', referUrl);
+			}
+
+			if (await dao.existData(targetData.url, date, contentText, referUrl)) {
+				logger.debug(`データ登録済み: ${contentText.substring(0, 30)}...`);
+				continue;
 			}
 
 			/* DB 書き込み */

--- a/node/src/component/crawlerNews.ts
+++ b/node/src/component/crawlerNews.ts
@@ -210,7 +210,7 @@ const exec = async (notice: Notice): Promise<void> => {
 				continue;
 			}
 
-			if (await dao.existData(targetData.url, contentText)) {
+			if (await dao.existData(targetData.url, date, contentText)) {
 				logger.debug(`データ登録済み: ${contentText.substring(0, 30)}...`);
 				continue;
 			}

--- a/node/src/dao/CrawlerNewsDao.ts
+++ b/node/src/dao/CrawlerNewsDao.ts
@@ -136,11 +136,12 @@ export default class CrawlerNewsDao {
 	 * ニュースデータが登録されているか
 	 *
 	 * @param url - URL
+	 * @param date - 日付
 	 * @param content - 内容
 	 *
 	 * @returns 登録件数
 	 */
-	async existData(url: URL, content: string): Promise<boolean> {
+	async existData(url: URL, date: Date | undefined, content: string): Promise<boolean> {
 		interface Select {
 			count: number;
 		}
@@ -149,6 +150,7 @@ export default class CrawlerNewsDao {
 
 		const { sqlWhere, bindParams } = prepareSelect({
 			url: url,
+			date: date,
 			content: content,
 		});
 

--- a/node/src/dao/CrawlerNewsDao.ts
+++ b/node/src/dao/CrawlerNewsDao.ts
@@ -138,10 +138,11 @@ export default class CrawlerNewsDao {
 	 * @param url - URL
 	 * @param date - 日付
 	 * @param content - 内容
+	 * @param referUrl - 参照 URL
 	 *
 	 * @returns 登録件数
 	 */
-	async existData(url: URL, date: Date | undefined, content: string): Promise<boolean> {
+	async existData(url: URL, date: Date | undefined, content: string, referUrl: string | undefined): Promise<boolean> {
 		interface Select {
 			count: number;
 		}
@@ -152,6 +153,7 @@ export default class CrawlerNewsDao {
 			url: url,
 			date: date,
 			content: content,
+			refer_url: referUrl,
 		});
 
 		const sth = await dbh.prepare(`


### PR DESCRIPTION
既存登録チェックの条件を URL と内容のみでチェックしていたため、同じ内容が複数存在する場合は新規登録がされていなかった。
毎年あるような定例イベント（例えば JR の「夏の臨時列車の運転について」）だと比較的そういったケースが発生しやすい。

そのためチェック条件に日付を追加した。
ただし日付が取得できないページの場合、引き続きこの不具合が残っている。