### PR TITLE
`crawler.db` のテーブル名、カラム名変更に対応

### DIFF
--- a/node/@types/db.d.ts
+++ b/node/@types/db.d.ts
@@ -2,7 +2,7 @@ declare namespace CrawlerDb {
 	export interface News {
 		url: URL;
 		title: string;
-		class: number;
+		category: number;
 		priority: number;
 		browser: boolean;
 		selectorWrap: string;

--- a/node/src/dao/CrawlerNewsDao.ts
+++ b/node/src/dao/CrawlerNewsDao.ts
@@ -53,7 +53,7 @@ export default class CrawlerNewsDao {
 		interface Select {
 			url: string;
 			title: string;
-			class: number;
+			category: number;
 			priority: number;
 			browser: number;
 			selector_wrap: string;
@@ -68,7 +68,7 @@ export default class CrawlerNewsDao {
 			SELECT
 				url,
 				title,
-				class,
+				category,
 				priority,
 				browser,
 				selector_wrap,
@@ -89,7 +89,7 @@ export default class CrawlerNewsDao {
 		return rows.map((row) => ({
 			url: sqliteToJS(row.url, 'url'),
 			title: sqliteToJS(row.title),
-			class: sqliteToJS(row.class),
+			category: sqliteToJS(row.category),
 			priority: sqliteToJS(row.priority),
 			browser: sqliteToJS(row.browser, 'boolean'),
 			selectorWrap: sqliteToJS(row.selector_wrap),


### PR DESCRIPTION
- `m_class` テーブル → `m_category`
- `d_news` テーブルの `class` カラム → `category`