### PR TITLE
pnpm 11.1.2 までダウングレード

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,4 @@
 # https://docs.npmjs.com/cli/v11/using-npm/config
 
 allow-git=none # expected to become the default in npm CLI v12 <https://github.blog/changelog/2026-02-18-npm-bulk-trusted-publishing-config-and-script-security-now-generally-available/>
-engine-strict=true
-min-release-age=1
 save-exact=true
-strict-peer-deps=true

--- a/package.json
+++ b/package.json
@@ -43,5 +43,5 @@
 		"typescript": "6.0.3",
 		"typescript-eslint": "8.59.3"
 	},
-	"packageManager": "pnpm@11.2.2"
+	"packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,14 @@ blockExoticSubdeps: true
 publicHoistPattern:
   - 'eslint'
 
+## Peer Dependency Settings
+
+strictPeerDependencies: true
+
+## CLI Settings
+
+engineStrict: true
+
 ## Build Settings
 
 strictDepBuilds: true


### PR DESCRIPTION
[pnpm 11.1.3](https://github.com/pnpm/pnpm/releases/tag/v11.1.3) 以降では `pnpm i` で以下のエラーが発生する

```
? Verifying lockfile against supply-chain policies (403 entries)...
[WARN] GET https://registry.npmjs.org/@typescript-eslint%2Feslint-plugin error (23). Will retry in 10 seconds. 2 retries left.
[WARN] GET https://registry.npmjs.org/@typescript-eslint%2Fparser error (23). Will retry in 10 seconds. 2 retries left.
[WARN] GET https://registry.npmjs.org/@typescript-eslint%2Ftypescript-estree error (23). Will retry in 10 seconds. 2 retries left.
[WARN] GET https://registry.npmjs.org/@typescript-eslint%2Feslint-plugin error (23). Will retry in 1 minute. 1 retries left.
[WARN] GET https://registry.npmjs.org/@typescript-eslint%2Fparser error (23). Will retry in 1 minute. 1 retries left.
[WARN] GET https://registry.npmjs.org/@typescript-eslint%2Ftypescript-estree error (23). Will retry in 1 minute. 1 retries left.
[WARN] GET https://registry.npmjs.org/playwright-core error (23). Will retry in 10 seconds. 2 retries left.
[WARN] GET https://registry.npmjs.org/playwright error (23). Will retry in 10 seconds. 2 retries left.
[WARN] GET https://registry.npmjs.org/typescript error (23). Will retry in 10 seconds. 2 retries left.
[WARN] GET https://registry.npmjs.org/playwright-core error (23). Will retry in 1 minute. 1 retries left.
[WARN] GET https://registry.npmjs.org/playwright error (23). Will retry in 1 minute. 1 retries left.
[WARN] GET https://registry.npmjs.org/typescript-eslint error (23). Will retry in 10 seconds. 2 retries left.

<--- Last few GCs --->

[442076:0x42a96000]   281542 ms: Mark-Compact (reduce) 254.4 (258.2) -> 254.2 (256.5) MB, pooled: 0 MB, 9943.60 / 0.21 ms  (+ 113.5 ms in 13 steps since start of marking, biggest step 18.3 ms, walltime since start of marking 10769 ms) (average mu = 0.360,[442076:0x42a96000]   287145 ms: Mark-Compact (reduce) 255.2 (256.5) -> 255.2 (257.5) MB, pooled: 0 MB, 4830.03 / 18.84 ms  (+ 266.4 ms in 15 steps since start of marking, biggest step 24.4 ms, walltime since start of marking 5570 ms) (average mu = 0.290,
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0x735eec node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
 2: 0xbafbd0  [node]
 3: 0xbafcbf  [node]
 4: 0xe49875  [node]
 5: 0xe5b1dc  [node]
 6: 0xe30693  [node]
 7: 0xe057e4  [node]
 8: 0xdf06d8  [node]
 9: 0xfbdc77  [node]
10: 0xfc9b57  [node]
11: 0xfc994a  [node]
12: 0xfc994a  [node]
13: 0xfc994a  [node]
14: 0xfcae2a  [node]
15: 0xfcb165  [node]
16: 0xc389b8  [node]
17: 0x1a088f6  [node]
Aborted (core dumped)
```